### PR TITLE
remove module entry when fake delete, add test

### DIFF
--- a/testsuite/delete_module.c
+++ b/testsuite/delete_module.c
@@ -133,50 +133,50 @@ TS_EXPORT long delete_module(const char *name, unsigned int flags);
 
 static int remove_directory(const char *path)
 {
-    struct stat st;
+	struct stat st;
 	DIR *dir;
 	struct dirent *entry;
 	char full_path[PATH_MAX];
 
-    if (stat(path, &st) != 0 || !S_ISDIR(st.st_mode)) {
+	if (stat(path, &st) != 0 || !S_ISDIR(st.st_mode)) {
 		LOG("Directory %s not found, skip remove.\n", path);
-        return 0;
-    }
+		return 0;
+	}
 
-    dir = opendir(path);
-    if (!dir) {
+	dir = opendir(path);
+	if (!dir) {
 		ERR("Failed to open directory %s: %s (errno: %d)\n", path, strerror(errno), errno);
-        return -1;
-    }
+		return -1;
+	}
 
-    while ((entry = readdir(dir)) != NULL) {
-        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
-            continue;
-        }
+	while ((entry = readdir(dir)) != NULL) {
+		if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+			continue;
+		}
 
-        snprintf(full_path, sizeof(full_path), "%s/%s", path, entry->d_name);
+		snprintf(full_path, sizeof(full_path), "%s/%s", path, entry->d_name);
 
-        if (entry->d_type == DT_DIR) {
-            if (remove_directory(full_path) != 0) {
-                closedir(dir);
+		if (entry->d_type == DT_DIR) {
+			if (remove_directory(full_path) != 0) {
+				closedir(dir);
 				ERR("Failed to remove directory %s: %s (errno: %d)\n", full_path, strerror(errno), errno);
-                return -1;
-            }
-        } else {
-            if (remove(full_path) != 0) {
-                closedir(dir);
+				return -1;
+			}
+		} else {
+			if (remove(full_path) != 0) {
+				closedir(dir);
 				ERR("Failed to remove file %s: %s (errno: %d)\n", full_path, strerror(errno), errno);
-                return -1;
-            }
-        }
-    }
+				return -1;
+			}
+		}
+	}
 
-    closedir(dir);
-    if (rmdir(path) != 0) {
-        ERR("Failed to remove directory %s: %s (errno: %d)\n", path, strerror(errno), errno);
-        return -1;
-    }
-    return 0;
+	closedir(dir);
+	if (rmdir(path) != 0) {
+		ERR("Failed to remove directory %s: %s (errno: %d)\n", path, strerror(errno), errno);
+		return -1;
+	}
+	return 0;
 }
 
 long delete_module(const char *modname, unsigned int flags)

--- a/testsuite/delete_module.c
+++ b/testsuite/delete_module.c
@@ -145,7 +145,8 @@ static int remove_directory(const char *path)
 
 	dir = opendir(path);
 	if (!dir) {
-		ERR("Failed to open directory %s: %s (errno: %d)\n", path, strerror(errno), errno);
+		ERR("Failed to open directory %s: %s (errno: %d)\n", path,
+		    strerror(errno), errno);
 		return -1;
 	}
 
@@ -159,13 +160,15 @@ static int remove_directory(const char *path)
 		if (entry->d_type == DT_DIR) {
 			if (remove_directory(full_path) != 0) {
 				closedir(dir);
-				ERR("Failed to remove directory %s: %s (errno: %d)\n", full_path, strerror(errno), errno);
+				ERR("Failed to remove directory %s: %s (errno: %d)\n",
+				    full_path, strerror(errno), errno);
 				return -1;
 			}
 		} else {
 			if (remove(full_path) != 0) {
 				closedir(dir);
-				ERR("Failed to remove file %s: %s (errno: %d)\n", full_path, strerror(errno), errno);
+				ERR("Failed to remove file %s: %s (errno: %d)\n", full_path,
+				    strerror(errno), errno);
 				return -1;
 			}
 		}
@@ -173,7 +176,8 @@ static int remove_directory(const char *path)
 
 	closedir(dir);
 	if (rmdir(path) != 0) {
-		ERR("Failed to remove directory %s: %s (errno: %d)\n", path, strerror(errno), errno);
+		ERR("Failed to remove directory %s: %s (errno: %d)\n", path,
+		    strerror(errno), errno);
 		return -1;
 	}
 	return 0;

--- a/testsuite/delete_module.c
+++ b/testsuite/delete_module.c
@@ -167,8 +167,8 @@ static int remove_directory(const char *path)
 		} else {
 			if (remove(full_path) != 0) {
 				closedir(dir);
-				ERR("Failed to remove file %s: %s (errno: %d)\n", full_path,
-				    strerror(errno), errno);
+				ERR("Failed to remove file %s: %s (errno: %d)\n",
+				    full_path, strerror(errno), errno);
 				return -1;
 			}
 		}

--- a/testsuite/delete_module.c
+++ b/testsuite/delete_module.c
@@ -130,9 +130,67 @@ TS_EXPORT long delete_module(const char *name, unsigned int flags);
  * Default behavior is to exit successfully. If this is not the intended
  * behavior, set TESTSUITE_DELETE_MODULE_RETCODES env var.
  */
+
+static int remove_directory(const char *path)
+{
+    struct stat st;
+	DIR *dir;
+	struct dirent *entry;
+	char full_path[PATH_MAX];
+
+    if (stat(path, &st) != 0 || !S_ISDIR(st.st_mode)) {
+		LOG("Directory %s not found, skip remove.\n", path);
+        return 0;
+    }
+
+    dir = opendir(path);
+    if (!dir) {
+		ERR("Failed to open directory %s: %s (errno: %d)\n", path, strerror(errno), errno);
+        return -1;
+    }
+
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+
+        snprintf(full_path, sizeof(full_path), "%s/%s", path, entry->d_name);
+
+        if (entry->d_type == DT_DIR) {
+            if (remove_directory(full_path) != 0) {
+                closedir(dir);
+				ERR("Failed to remove directory %s: %s (errno: %d)\n", full_path, strerror(errno), errno);
+                return -1;
+            }
+        } else {
+            if (remove(full_path) != 0) {
+                closedir(dir);
+				ERR("Failed to remove file %s: %s (errno: %d)\n", full_path, strerror(errno), errno);
+                return -1;
+            }
+        }
+    }
+
+    closedir(dir);
+    if (rmdir(path) != 0) {
+        ERR("Failed to remove directory %s: %s (errno: %d)\n", path, strerror(errno), errno);
+        return -1;
+    }
+    return 0;
+}
+
 long delete_module(const char *modname, unsigned int flags)
 {
 	struct mod *mod;
+	int ret = 0;
+	char buf[PATH_MAX];
+	const char *sysfsmod = "/sys/module/";
+	int len = strlen(sysfsmod);
+	memcpy(buf, sysfsmod, len);
+	strcpy(buf + len, modname);
+	ret = remove_directory(buf);
+	if (ret != 0)
+		return ret;
 
 	init_retcodes();
 	mod = find_module(modules, modname);

--- a/testsuite/meson.build
+++ b/testsuite/meson.build
@@ -95,6 +95,7 @@ _testsuite = [
   'test-testsuite',
   'test-util',
   'test-weakdep',
+  'test-remove'
 ]
 
 if get_option('b_sanitize') != 'none'

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -180,6 +180,8 @@ static void *get_libc_func(const char *f)
 
 WRAP_1ARG(DIR *, NULL, opendir);
 WRAP_1ARG(int, -1, chdir);
+WRAP_1ARG(int, -1, remove);
+WRAP_1ARG(int, -1, rmdir);
 
 WRAP_2ARGS(FILE *, NULL, fopen, const char *);
 WRAP_2ARGS(int, -1, mkdir, mode_t);

--- a/testsuite/test-remove.c
+++ b/testsuite/test-remove.c
@@ -18,7 +18,7 @@ static noreturn int test_remove(const struct test *t)
 	struct kmod_module *mod;
 	const char *null_config = NULL;
 	int err;
-    struct stat st;
+	struct stat st;
 
 	ctx = kmod_new(NULL, &null_config);
 	if (ctx == NULL)
@@ -42,20 +42,20 @@ static noreturn int test_remove(const struct test *t)
 		exit(EXIT_FAILURE);
 	}
 
-    if (stat("/sys/module/mod_simple", &st) == 0 && S_ISDIR(st.st_mode)) {
+	if (stat("/sys/module/mod_simple", &st) == 0 && S_ISDIR(st.st_mode)) {
 		ERR("could not remove module directory.\n");
-        exit(EXIT_FAILURE);
-    }
+		exit(EXIT_FAILURE);
+	}
 	kmod_unref(ctx);
 
 	exit(EXIT_SUCCESS);
 }
 DEFINE_TEST(test_remove,
-	.description = "test if libkmod's delete_module removes module directory",
-	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-remove/",
-		[TC_INIT_MODULE_RETCODES] = "",
-		[TC_DELETE_MODULE_RETCODES] = "mod_simple:0:0" STRINGIFY(ENOENT),
-	});
+	    .description = "test if libkmod's delete_module removes module directory",
+	    .config = {
+		    [TC_ROOTFS] = TESTSUITE_ROOTFS "test-remove/",
+		    [TC_INIT_MODULE_RETCODES] = "",
+		    [TC_DELETE_MODULE_RETCODES] = "mod_simple:0:0" STRINGIFY(ENOENT),
+	    });
 
 TESTSUITE_MAIN();

--- a/testsuite/test-remove.c
+++ b/testsuite/test-remove.c
@@ -1,0 +1,61 @@
+#include <errno.h>
+#include <inttypes.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <shared/macro.h>
+
+#include <libkmod/libkmod.h>
+
+#include "testsuite.h"
+
+static noreturn int test_remove(const struct test *t)
+{
+	struct kmod_ctx *ctx;
+	struct kmod_module *mod;
+	const char *null_config = NULL;
+	int err;
+    struct stat st;
+
+	ctx = kmod_new(NULL, &null_config);
+	if (ctx == NULL)
+		exit(EXIT_FAILURE);
+
+	err = kmod_module_new_from_path(ctx, "/mod-simple.ko", &mod);
+	if (err != 0) {
+		ERR("could not create module from path: %m\n");
+		exit(EXIT_FAILURE);
+	}
+
+	err = kmod_module_insert_module(mod, 0, NULL);
+	if (err != 0) {
+		ERR("could not insert module: %m\n");
+		exit(EXIT_FAILURE);
+	}
+
+	err = kmod_module_remove_module(mod, 0);
+	if (err != 0) {
+		ERR("could not remove module: %m\n");
+		exit(EXIT_FAILURE);
+	}
+
+    if (stat("/sys/module/mod_simple", &st) == 0 && S_ISDIR(st.st_mode)) {
+		ERR("could not remove module directory.\n");
+        exit(EXIT_FAILURE);
+    }
+	kmod_unref(ctx);
+
+	exit(EXIT_SUCCESS);
+}
+DEFINE_TEST(test_remove,
+	.description = "test if libkmod's delete_module removes module directory",
+	.config = {
+		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-remove/",
+		[TC_INIT_MODULE_RETCODES] = "",
+		[TC_DELETE_MODULE_RETCODES] = "mod_simple:0:0" STRINGIFY(ENOENT),
+	});
+
+TESTSUITE_MAIN();


### PR DESCRIPTION
[Issue: 49] testsuite: Improve fake_delete behavior

- When fake delete_module() succeeds, remove its entry from /sys/module.
- Add tests to ensure module is properly removed.


Co-developed-by: Qingqing Li <qingqing.li@intel.com>
Signed-off-by: Qingqing Li <qingqing.li@intel.com>
Signed-off-by: Gongjun Song <gongjun.song@intel.com>
Signed-off-by: Dan He <dan.h.he@intel.com>
Signed-off-by: Yuchi Chen <yuchi.chen@intel.com>
Signed-off-by: Wenjie Wang <wenjie2.wang@intel.com>